### PR TITLE
added additional test

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,7 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=

--- a/internal/lockserver/lockserver_test.go
+++ b/internal/lockserver/lockserver_test.go
@@ -9,8 +9,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestSingleLockAndRelease(t *testing.T) {
-	go StartServer()
+func TestDoubleLockAndRelease(t *testing.T) {
+	t.Logf("acquire a release a acquire a release a")
+	// go StartServer()
 	assert := assert.New(t)
 	client, err := rpc.DialHTTP("tcp", "localhost:55550")
 	if err != nil {
@@ -29,4 +30,49 @@ func TestSingleLockAndRelease(t *testing.T) {
 	if err != nil {
 		assert.Fail(fmt.Sprintf("Failed to release lock: %v", err))
 	}
+
+	err = client.Call("Service.Acquire", "1", &y)
+
+	if err != nil {
+		assert.Fail(fmt.Sprintf("Failed to acquire lock: %v", err))
+	}
+	err = client.Call("Service.Release", "1", &y)
+	if err != nil {
+		assert.Fail(fmt.Sprintf("Failed to release lock: %v", err))
+	}
+
+	t.Logf("PASSED")
+
+}
+
+func TestMultipleLockAndRelease(t *testing.T) {
+	t.Logf("acquire a acquire b release b release a\n")
+	assert := assert.New(t)
+	client, err := rpc.DialHTTP("tcp", "localhost:55550")
+
+	var y float32
+	y = 3.4
+	if err != nil {
+		log.Fatal("Connection error: ", err)
+	}
+	err = client.Call("Service.Acquire", "1", &y)
+
+	if err != nil {
+		assert.Fail(fmt.Sprintf("Failed to acquire lock: %v", err))
+	}
+	err = client.Call("Service.Acquire", "2", &y)
+	if err != nil {
+		assert.Fail(fmt.Sprintf("Failed to release lock: %v", err))
+	}
+
+	err = client.Call("Service.Release", "2", &y)
+	if err != nil {
+		assert.Fail(fmt.Sprintf("Failed to release lock: %v", err))
+	}
+
+	err = client.Call("Service.Release", "1", &y)
+	if err != nil {
+		assert.Fail(fmt.Sprintf("Failed to release lock: %v", err))
+	}
+
 }


### PR DESCRIPTION
removed the `goStartServer()` line as it was not running the server in the background. A dial-up request resulted in a `Connection Refused`. Needs to be fixed. 

I will continue adding more tests and add `checkAcquire()` and `checkRelease()` functions as well